### PR TITLE
fix(printability): robust facet normals + bed-volume tolerance in mesh validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the PrintProof3D project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Overhang/bridge/bed-contact detection no longer trusts STL file normals.** The mesh validator
+  read each facet's normal straight from the STL file for its downward-facing checks and *skipped*
+  any facet whose stored normal was zero-length. Many exporters (and most binary STLs) write
+  `0 0 0` normals and leave the slicer to derive them from winding — so a model with zeroed/garbage
+  normals silently produced **no** `OVERHANG_UNSUPPORTED`/`BRIDGE_UNSUPPORTED` findings (and a false
+  `POOR_BED_ADHESION`), flipping a real `warning` to a `pass`. The checks now fall back to the
+  geometric normal computed from the vertex winding when the stored normal is missing/degenerate
+  (files with valid normals are unchanged). New `effective_facet_normal` helper + tests.
+- **`MODEL_OUT_OF_BOUNDS` no longer false-fails a model resting on the bed.** The build-volume
+  bounds check used a hard `< 0.0` lower bound with no tolerance, contradicting the dedicated
+  below-bed check's `-0.05 mm` tolerance — so a model sitting on the bed (or placed flush in a
+  corner) with sub-millimeter float/placement noise (e.g. `Z min = -0.03`) was reported as a
+  `Critical` out-of-bounds `fail`. The rectangular and cylindrical bounds checks now apply a
+  `BUILD_VOLUME_TOL` (0.05 mm, matching the below-bed check) to both lower and upper bounds; a model
+  genuinely outside the volume still fails. New tests.
+
 ## [0.5.0-rc2] - 2026-06-02
 
 ### Added

--- a/crates/printability/src/lib.rs
+++ b/crates/printability/src/lib.rs
@@ -90,6 +90,41 @@ fn cross_product(u: [f32; 3], v: [f32; 3]) -> [f32; 3] {
     ]
 }
 
+/// Tolerance (mm) for build-volume bounds checks. A model resting on the bed (Z min ~= 0), placed
+/// flush in a corner, or exactly filling the volume must not be failed by sub-millimeter float /
+/// placement noise. Matches the tolerance the dedicated below-bed check already uses.
+const BUILD_VOLUME_TOL: f32 = 0.05;
+
+/// The facet's effective surface normal for geometry checks (overhang / bridge / bed contact).
+/// Prefers the STL file's stored normal when it is usable, but falls back to the geometric normal
+/// computed from the vertex winding when the stored normal is missing or degenerate (zero-length).
+/// Many exporters — and most binary STLs — write `0 0 0` normals and leave the slicer to derive
+/// them from winding; trusting the stored normal there silently disables overhang / bridge / bed
+/// detection (the report flips to a false "pass"). Returns `[0,0,0]` only for a genuinely
+/// degenerate (zero-area) triangle, which the callers already skip.
+fn effective_facet_normal(facet: &StlFacet) -> [f32; 3] {
+    let stored = facet.normal;
+    if magnitude(stored) >= 1e-6 {
+        return stored;
+    }
+    let u = [
+        facet.vertices[1][0] - facet.vertices[0][0],
+        facet.vertices[1][1] - facet.vertices[0][1],
+        facet.vertices[1][2] - facet.vertices[0][2],
+    ];
+    let v = [
+        facet.vertices[2][0] - facet.vertices[0][0],
+        facet.vertices[2][1] - facet.vertices[0][1],
+        facet.vertices[2][2] - facet.vertices[0][2],
+    ];
+    let n = cross_product(u, v);
+    let len = magnitude(n);
+    if len < 1e-6 {
+        return [0.0, 0.0, 0.0];
+    }
+    [n[0] / len, n[1] / len, n[2] / len]
+}
+
 fn parse_binary_stl(bytes: &[u8]) -> Result<Vec<StlFacet>, String> {
     if bytes.len() < 84 {
         return Err("Binary STL too short".to_string());
@@ -353,22 +388,25 @@ impl ModelValidator for StlModelValidator {
         let mut out_of_bounds = false;
         match &printer.build_volume {
             BuildVolume::Rectangular { x, y, z } => {
-                if min_x < 0.0
-                    || max_x > *x
-                    || min_y < 0.0
-                    || max_y > *y
-                    || min_z < 0.0
-                    || max_z > *z
+                if min_x < -BUILD_VOLUME_TOL
+                    || max_x > *x + BUILD_VOLUME_TOL
+                    || min_y < -BUILD_VOLUME_TOL
+                    || max_y > *y + BUILD_VOLUME_TOL
+                    || min_z < -BUILD_VOLUME_TOL
+                    || max_z > *z + BUILD_VOLUME_TOL
                 {
                     out_of_bounds = true;
                 }
             }
             BuildVolume::Cylindrical { diameter, z } => {
-                let r_max = diameter / 2.0;
+                let r_max = diameter / 2.0 + BUILD_VOLUME_TOL;
                 for facet in &facets {
                     for v in &facet.vertices {
                         let r2 = v[0] * v[0] + v[1] * v[1];
-                        if r2 > r_max * r_max || v[2] < 0.0 || v[2] > *z {
+                        if r2 > r_max * r_max
+                            || v[2] < -BUILD_VOLUME_TOL
+                            || v[2] > *z + BUILD_VOLUME_TOL
+                        {
                             out_of_bounds = true;
                             break;
                         }
@@ -520,7 +558,9 @@ impl ModelValidator for StlModelValidator {
         let overhang_cos_thresh = (overhang_thresh_deg.to_radians()).cos();
 
         for facet in &facets {
-            let n = facet.normal;
+            // Use the geometric normal when the file normal is missing/degenerate, so a mesh with
+            // zeroed STL normals doesn't silently skip overhang/bridge detection.
+            let n = effective_facet_normal(facet);
             let len = magnitude(n);
             if len < 1e-6 {
                 continue;
@@ -592,7 +632,7 @@ impl ModelValidator for StlModelValidator {
         let mut bed_contact_area = 0.0f32;
         for facet in &facets {
             let on_bed = facet.vertices.iter().all(|v| v[2] < 0.05);
-            let facing_down = facet.normal[2] < -0.9;
+            let facing_down = effective_facet_normal(facet)[2] < -0.9;
             if on_bed && facing_down {
                 let u = [
                     facet.vertices[1][0] - facet.vertices[0][0],
@@ -1392,6 +1432,117 @@ mod tests {
             .issues
             .iter()
             .any(|issue| issue.id == "BELOW_BED_GEOMETRY"));
+    }
+
+    #[test]
+    fn test_effective_facet_normal_falls_back_to_geometry() {
+        // A downward-facing triangle whose stored normal is zeroed: the helper must return the
+        // geometric normal (pointing -Z), not a useless [0,0,0].
+        let zeroed = StlFacet {
+            normal: [0.0, 0.0, 0.0],
+            vertices: [[0.0, 0.0, 5.0], [0.0, 10.0, 5.0], [10.0, 0.0, 5.0]],
+        };
+        let n = effective_facet_normal(&zeroed);
+        assert!(magnitude(n) > 0.99, "expected a unit geometric normal, got {:?}", n);
+        assert!(n[2] < -0.99, "expected the geometric normal to point down (-Z), got {:?}", n);
+
+        // A facet with a usable stored normal is returned unchanged (no regression for good files).
+        let good = StlFacet {
+            normal: [0.0, 0.0, 1.0],
+            vertices: [[0.0, 0.0, 5.0], [10.0, 0.0, 5.0], [0.0, 10.0, 5.0]],
+        };
+        assert_eq!(effective_facet_normal(&good), [0.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn test_overhang_detected_with_zeroed_stl_normals() {
+        // Regression: an overhang must still be found when the STL's stored normals are zeroed
+        // (common from many exporters / binary STLs). The overhang loop previously trusted the
+        // stored normal and silently skipped these facets, flipping a real warning to a false pass.
+        let (fixtures_dir, printer, material) = get_fixtures_and_profiles();
+        let src = std::fs::read_to_string(fixtures_dir.join("overhang_flange.stl")).unwrap();
+        let zeroed: String = src
+            .lines()
+            .map(|line| {
+                if line.trim_start().to_lowercase().starts_with("facet normal") {
+                    "facet normal 0 0 0".to_string()
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let temp_path = std::env::temp_dir().join("ppd_zeroed_overhang.stl");
+        std::fs::write(&temp_path, zeroed).unwrap();
+
+        let validator = StlModelValidator;
+        let report = validator.validate_mesh(&temp_path, &printer, &material).unwrap();
+        std::fs::remove_file(&temp_path).ok();
+
+        assert!(
+            report.issues.iter().any(|i| i.id == "OVERHANG_UNSUPPORTED"),
+            "overhang must be detected even with zeroed STL normals; got: {:?}",
+            report.issues.iter().map(|i| &i.id).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_model_resting_on_bed_within_tolerance_is_not_out_of_bounds() {
+        // Regression: a model resting on the bed with sub-tolerance float/placement noise (Z min a
+        // few hundredths of a mm below 0, well inside the below-bed tolerance) must NOT be flagged
+        // out-of-bounds — while a model genuinely below the bed still must be.
+        fn cube_stl(zmin: f32) -> String {
+            let (x0, x1, y0, y1, z0, z1) = (10.0f32, 20.0, 10.0, 20.0, zmin, zmin + 10.0);
+            let c = [
+                [x0, y0, z0], [x1, y0, z0], [x1, y1, z0], [x0, y1, z0],
+                [x0, y0, z1], [x1, y0, z1], [x1, y1, z1], [x0, y1, z1],
+            ];
+            let faces: [([usize; 3], [usize; 3], [f32; 3]); 6] = [
+                ([0, 3, 2], [0, 2, 1], [0.0, 0.0, -1.0]),
+                ([4, 5, 6], [4, 6, 7], [0.0, 0.0, 1.0]),
+                ([0, 1, 5], [0, 5, 4], [0.0, -1.0, 0.0]),
+                ([2, 3, 7], [2, 7, 6], [0.0, 1.0, 0.0]),
+                ([1, 2, 6], [1, 6, 5], [1.0, 0.0, 0.0]),
+                ([0, 4, 7], [0, 7, 3], [-1.0, 0.0, 0.0]),
+            ];
+            let mut s = String::from("solid cube\n");
+            for (a, b, n) in faces.iter() {
+                for tri in [a, b] {
+                    s.push_str(&format!(" facet normal {} {} {}\n  outer loop\n", n[0], n[1], n[2]));
+                    for &idx in tri.iter() {
+                        s.push_str(&format!(
+                            "   vertex {:.4} {:.4} {:.4}\n",
+                            c[idx][0], c[idx][1], c[idx][2]
+                        ));
+                    }
+                    s.push_str("  endloop\n endfacet\n");
+                }
+            }
+            s.push_str("endsolid cube\n");
+            s
+        }
+
+        let (_fixtures, printer, material) = get_fixtures_and_profiles();
+        let validator = StlModelValidator;
+
+        let near = std::env::temp_dir().join("ppd_bed_within_tol.stl");
+        std::fs::write(&near, cube_stl(-0.03)).unwrap();
+        let r = validator.validate_mesh(&near, &printer, &material).unwrap();
+        std::fs::remove_file(&near).ok();
+        assert!(
+            !r.issues.iter().any(|i| i.id == "MODEL_OUT_OF_BOUNDS"),
+            "a model resting on the bed within tolerance must not be out-of-bounds; got: {:?}",
+            r.issues.iter().map(|i| &i.id).collect::<Vec<_>>()
+        );
+
+        let below = std::env::temp_dir().join("ppd_bed_below.stl");
+        std::fs::write(&below, cube_stl(-1.0)).unwrap();
+        let r2 = validator.validate_mesh(&below, &printer, &material).unwrap();
+        std::fs::remove_file(&below).ok();
+        assert!(
+            r2.issues.iter().any(|i| i.id == "MODEL_OUT_OF_BOUNDS"),
+            "a model 1mm below the bed must still be out-of-bounds"
+        );
     }
 
     #[test]

--- a/crates/printability/src/lib.rs
+++ b/crates/printability/src/lib.rs
@@ -104,8 +104,9 @@ const BUILD_VOLUME_TOL: f32 = 0.05;
 /// degenerate (zero-area) triangle, which the callers already skip.
 fn effective_facet_normal(facet: &StlFacet) -> [f32; 3] {
     let stored = facet.normal;
-    if magnitude(stored) >= 1e-6 {
-        return stored;
+    let stored_len = magnitude(stored);
+    if stored_len >= 1e-6 {
+        return [stored[0] / stored_len, stored[1] / stored_len, stored[2] / stored_len];
     }
     let u = [
         facet.vertices[1][0] - facet.vertices[0][0],
@@ -473,7 +474,7 @@ impl ModelValidator for StlModelValidator {
         }
 
         // 2b. Below Bed Geometry Check
-        if min_z < -0.05 {
+        if min_z < -BUILD_VOLUME_TOL {
             issues.push(ValidationIssue {
                 id: "BELOW_BED_GEOMETRY".to_string(),
                 severity: IssueSeverity::Major,
@@ -569,7 +570,7 @@ impl ModelValidator for StlModelValidator {
             // Facing downwards
             if n[2] < -0.01 {
                 let min_facet_z = facet.vertices.iter().map(|v| v[2]).fold(f32::MAX, f32::min);
-                if min_facet_z > 0.05 {
+                if min_facet_z > BUILD_VOLUME_TOL {
                     let cos_theta = -n[2] / len;
                     if cos_theta > 0.99 {
                         bridge_triangles.push(Triangle {
@@ -631,7 +632,7 @@ impl ModelValidator for StlModelValidator {
         // 4. Bed Adhesion Heuristics
         let mut bed_contact_area = 0.0f32;
         for facet in &facets {
-            let on_bed = facet.vertices.iter().all(|v| v[2] < 0.05);
+            let on_bed = facet.vertices.iter().all(|v| v[2] < BUILD_VOLUME_TOL);
             let facing_down = effective_facet_normal(facet)[2] < -0.9;
             if on_bed && facing_down {
                 let u = [


### PR DESCRIPTION
Two correctness bugs in the `StlModelValidator` mesh path (`crates/printability/src/lib.rs`), found while integrating the `validate-model` CLI into an external tool. Both are **reproduced against the release binary** and fixed with tests. `cargo test --workspace` is green (printability: 25 passed, 0 failed).

---

### Bug 1 — overhang/bridge/bed-contact detection trusts STL file normals (false `pass`)

The downward-facing checks read each facet's normal **straight from the STL file** and *skip* any facet whose stored normal is zero-length (`if len < 1e-6 { continue; }`). The parser passes the file normal through verbatim — it never recomputes it. But many CAD exporters, and **most binary STLs**, write `0 0 0` normals and leave the slicer to derive them from the vertex winding. For such a model the overhang loop skips every facet, so the validator emits **no** `OVERHANG_UNSUPPORTED` / `BRIDGE_UNSUPPORTED` and a false `POOR_BED_ADHESION` — silently turning a real `warning` into a `pass`. This defeats the validator's headline safety feature for a large, common class of inputs.

**Reproduced** (release binary): `fixtures/overhang_flange.stl` validates as `warning` with `OVERHANG_UNSUPPORTED`; the **same geometry with every `facet normal` zeroed** validates as `pass` — the overhang disappears.

**Fix:** a new `effective_facet_normal()` helper returns the stored normal when it's usable and otherwise falls back to the **geometric normal computed from the vertex winding** (the cross product the code already computes for the area check). The overhang/bridge loop and the bed-adhesion check use it. Files with valid normals are unchanged (verified — `test_validate_mesh_overhang_flange` still passes).

### Bug 2 — `MODEL_OUT_OF_BOUNDS` false-fails a model resting on the bed

The build-volume fit check uses a hard `< 0.0` lower bound with **no tolerance**:
```rust
if min_x < 0.0 || max_x > *x || min_y < 0.0 || max_y > *y || min_z < 0.0 || max_z > *z { ... }
```
This contradicts the dedicated below-bed check a few lines down, which deliberately tolerates `-0.05 mm` (`if min_z < -0.05`). So a model resting on the bed (or placed flush in a corner / exactly filling the volume) with sub-millimeter float or placement noise — e.g. `Z min = -0.03`, **well inside** the below-bed tolerance — is reported as a `Critical` `MODEL_OUT_OF_BOUNDS` and the report `fail`s, while `BELOW_BED_GEOMETRY` stays silent. The two checks disagree about the same model.

**Reproduced** (release binary): a 10 mm cube with its base at `Z = 0` → `pass`; the **same cube at `Z = -0.03`** → `fail` / `MODEL_OUT_OF_BOUNDS`.

**Fix:** a `BUILD_VOLUME_TOL` (`0.05 mm`, matching the below-bed check) applied to **both** lower and upper bounds in the rectangular *and* cylindrical cases. A model genuinely outside the volume still fails (covered by a control assertion + the existing `test_validate_mesh_oversized` / `test_validate_mesh_below_bed`).

---

### Tests added
- `test_effective_facet_normal_falls_back_to_geometry` — the helper returns the geometric normal for a zeroed stored normal, and the stored normal unchanged otherwise.
- `test_overhang_detected_with_zeroed_stl_normals` — `overhang_flange.stl` with zeroed normals still reports `OVERHANG_UNSUPPORTED`.
- `test_model_resting_on_bed_within_tolerance_is_not_out_of_bounds` — a cube at `Z min = -0.03` is not out-of-bounds; a control at `Z min = -1.0` still is.

Both fixes are localized to `crates/printability/src/lib.rs`; no public API or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)