### PR TITLE
chore(release): v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-06-23
+
 ### Added
 - **Coverage-guided fuzzing**: New standalone `fuzz/` crate with `cargo-fuzz` targets for the STL parser (`parse_stl_bytes`) and the G-code validator, plus a scheduled `Fuzz` CI workflow. The same never-panic contract is guarded on stable in normal CI by `proptest` smoke tests in `crates/printability`.
 - **`tls_enabled` enforcement**: Setting `tls_enabled` on an HTTP-based connection (Klipper/Moonraker, OctoPrint, PrusaLink, RepRapFirmware) now requires an `https://` `base_url`; configuration validation fails closed otherwise. The field was previously unused.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "example-plugin"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "printproof3d-core",
  "printproof3d-plugins",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "printproof3d"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clap",
  "printproof3d-adapters",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "printproof3d-adapters"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "printproof3d-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "schemars",
  "serde",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "printproof3d-plugins"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "printproof3d-core",
  "serde",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "printproof3d-printability"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "printproof3d-core",
  "proptest",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "printproof3d-rest"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "axum",
  "printproof3d-core",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "printproof3d-sdk"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,4 +1,4 @@
-# PrintProof3D Release Checklist & Guide (v0.6.1)
+# PrintProof3D Release Checklist & Guide (v0.6.2)
 
 This checklist and guide outlines the packaging, platform compatibility, and verification steps necessary to declare a stable standalone release for **PrintProof3D**.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ Only the latest release (including release candidates) is supported with securit
 
 | Version | Supported |
 | --- | --- |
-| `0.6.1` | :white_check_mark: Yes |
-| < `0.6.1` | :x: No |
+| `0.6.2` | :white_check_mark: Yes |
+| < `0.6.2` | :x: No |
 
 ## Reporting a Vulnerability
 

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "printproof3d-adapters"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Printer connection adapters for PrintProof3D."
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "printproof3d"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "CLI tool for PrintProof3D."
 license = "MIT"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "printproof3d-core"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Core schemas and data models for PrintProof3D."
 license = "MIT"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(version(), "0.6.1");
+        assert_eq!(version(), "0.6.2");
     }
 
     #[test]

--- a/crates/example-plugin/Cargo.toml
+++ b/crates/example-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-plugin"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Example dynamic WASM plugin for PrintProof3D."
 license = "MIT"

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "printproof3d-plugins"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Dynamic sandboxed WASM validation plugin system for PrintProof3D."
 license = "MIT"

--- a/crates/printability/Cargo.toml
+++ b/crates/printability/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "printproof3d-printability"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Printability engine for PrintProof3D."
 license = "MIT"

--- a/crates/rest/Cargo.toml
+++ b/crates/rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "printproof3d-rest"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "REST API server for PrintProof3D."
 license = "MIT"

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "printproof3d-sdk"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Developer SDK for PrintProof3D."
 license = "MIT"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -135,7 +135,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "printproof3d-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "schemars",
  "serde",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "printproof3d-printability"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "printproof3d-core",
  "serde",

--- a/index.html
+++ b/index.html
@@ -607,7 +607,7 @@
     <a href="index.html" class="logo-link" style="text-decoration: none; color: inherit;">
       <div class="logo-container">
         <h1 class="logo">PrintProof3D</h1>
-        <div class="status-badge">v0.6.1</div>
+        <div class="status-badge">v0.6.2</div>
       </div>
     </a>
     <div class="nav-links">


### PR DESCRIPTION
Cuts **v0.6.2**, capturing the parser-fuzzing and `tls_enabled` work (merged in #9) into a tagged release so downstream consumers can pin to it.

**Version/metadata only — no code changes.**

- Bump all 8 workspace crates `0.6.1 → 0.6.2` (+ the `version()` unit test).
- Roll CHANGELOG `[Unreleased] → [0.6.2]`:
  - *Added*: coverage-guided fuzzing (`fuzz/` + `Fuzz` workflow + `proptest` smoke tests); `tls_enabled` fail-closed enforcement.
  - *Security*: checked arithmetic in the binary-STL header length check.
- Update `SECURITY.md` supported-versions table, `RELEASE_CHECKLIST.md` title, and the dashboard badge in `index.html`.
- Refresh `Cargo.lock` and `fuzz/Cargo.lock`.

## Verification
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` → **118 passed** ✓
- `cargo +nightly check` (fuzz crate) ✓
- `docs_policy_check.py` ✓ · `docs_drift_check.py` ✓

After merge, `v0.6.2` will be tagged on the merge commit so `{ git = "...", tag = "v0.6.2" }` resolves to everything currently on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)